### PR TITLE
Expose Batcher#sendOutstanding to provide async batch flushing

### DIFF
--- a/gax/src/main/java/com/google/api/gax/batching/Batcher.java
+++ b/gax/src/main/java/com/google/api/gax/batching/Batcher.java
@@ -63,6 +63,14 @@ public interface Batcher<ElementT, ElementResultT> extends AutoCloseable {
   void flush() throws InterruptedException;
 
   /**
+   * Sends accumulated elements asynchronously for batching.
+   *
+   * <p>Note: This method can be invoked concurrently unlike {@link #add} and {@link #close}, which
+   * can only be called from a single user thread. Please take caution to avoid race condition.
+   */
+  void sendOutstanding();
+
+  /**
    * Closes this Batcher by preventing new elements from being added and flushing the existing
    * elements.
    */


### PR DESCRIPTION
Now `Batcher` supports asynchronously batching.

Note: This is needed to support HBase client's [BulkMutation#sendUnsent](https://github.com/googleapis/java-bigtable-hbase/blob/master/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java#L37-L38) through GCJ client.