### PR TITLE
test: cleaning up deprecated usages

### DIFF
--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcCallContextTest.java
@@ -46,9 +46,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Rule;
+import org.junit.Assert;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
@@ -56,12 +55,17 @@ import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class GrpcCallContextTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testNullToSelfWrongType() {
-    thrown.expect(IllegalArgumentException.class);
-    GrpcCallContext.createDefault().nullToSelf(FakeCallContext.createDefault());
+    try {
+      GrpcCallContext.createDefault().nullToSelf(FakeCallContext.createDefault());
+      Assert.fail("GrpcCallContext should have thrown an exception");
+    } catch (IllegalArgumentException expected) {
+      Truth.assertThat(expected)
+          .hasMessageThat()
+          .contains("context must be an instance of GrpcCallContext");
+    }
   }
 
   @Test
@@ -83,15 +87,25 @@ public class GrpcCallContextTest {
 
   @Test
   public void testWithTransportChannelWrongType() {
-    thrown.expect(IllegalArgumentException.class);
     FakeChannel channel = new FakeChannel();
-    GrpcCallContext.createDefault().withTransportChannel(FakeTransportChannel.create(channel));
+    try {
+      GrpcCallContext.createDefault().withTransportChannel(FakeTransportChannel.create(channel));
+      Assert.fail("GrpcCallContext should have thrown an exception");
+    } catch (IllegalArgumentException expected) {
+      Truth.assertThat(expected).hasMessageThat().contains("Expected GrpcTransportChannel");
+    }
   }
 
   @Test
   public void testMergeWrongType() {
-    thrown.expect(IllegalArgumentException.class);
-    GrpcCallContext.createDefault().merge(FakeCallContext.createDefault());
+    try {
+      GrpcCallContext.createDefault().merge(FakeCallContext.createDefault());
+      Assert.fail("GrpcCallContext should have thrown an exception");
+    } catch (IllegalArgumentException expected) {
+      Truth.assertThat(expected)
+          .hasMessageThat()
+          .contains("context must be an instance of " + "GrpcCallContext");
+    }
   }
 
   @Test

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectServerStreamingCallableTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectServerStreamingCallableTest.java
@@ -58,10 +58,9 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -78,8 +77,6 @@ public class GrpcDirectServerStreamingCallableTest {
   private ClientContext clientContext;
   private ServerStreamingCallSettings<Color, Money> streamingCallSettings;
   private ServerStreamingCallable<Color, Money> streamingCallable;
-
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Before
   public void setUp() throws InstantiationException, IllegalAccessException, IOException {
@@ -121,9 +118,14 @@ public class GrpcDirectServerStreamingCallableTest {
 
     CountDownLatch latch = new CountDownLatch(1);
     MoneyObserver observer = new MoneyObserver(true, latch);
-
-    thrown.expect(IllegalArgumentException.class);
-    streamingCallable.call(DEFAULT_REQUEST, observer);
+    try {
+      streamingCallable.call(DEFAULT_REQUEST, observer);
+      Assert.fail("Callable should have thrown an exception");
+    } catch (IllegalArgumentException expected) {
+      Truth.assertThat(expected)
+          .hasMessageThat()
+          .contains("context must be an instance of GrpcCallContext");
+    }
   }
 
   @Test

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectStreamingCallableTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcDirectStreamingCallableTest.java
@@ -55,9 +55,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -67,8 +65,6 @@ public class GrpcDirectStreamingCallableTest {
   private ManagedChannel channel;
   private FakeServiceImpl serviceImpl;
   private ClientContext clientContext;
-
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Before
   public void setUp() throws InstantiationException, IllegalAccessException, IOException {

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcTransportDescriptorTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcTransportDescriptorTest.java
@@ -48,9 +48,7 @@ import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import java.util.Collections;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -58,8 +56,6 @@ import org.junit.runners.JUnit4;
 public class GrpcTransportDescriptorTest {
   private static boolean NOT_RETRYABLE = false;
   private static boolean IS_RETRYABLE = true;
-
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void translateException_StatusException_noRetry() throws Exception {

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/ProtoOperationTransformersTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/ProtoOperationTransformersTest.java
@@ -29,13 +29,12 @@
  */
 package com.google.api.gax.grpc;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.api.gax.grpc.ProtoOperationTransformers.MetadataTransformer;
 import com.google.api.gax.grpc.ProtoOperationTransformers.ResponseTransformer;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.UnavailableException;
+import com.google.common.truth.Truth;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.rpc.Status;
@@ -57,7 +56,7 @@ public class ProtoOperationTransformersTest {
     OperationSnapshot operationSnapshot =
         GrpcOperationSnapshot.create(
             Operation.newBuilder().setResponse(Any.pack(inputMoney)).build());
-    assertThat(transformer.apply(operationSnapshot)).isEqualTo(inputMoney);
+    Truth.assertThat(transformer.apply(operationSnapshot)).isEqualTo(inputMoney);
   }
 
   @Test
@@ -72,7 +71,7 @@ public class ProtoOperationTransformersTest {
       transformer.apply(operationSnapshot);
       Assert.fail("ResponseTransformer should have thrown an exception");
     } catch (UnavailableException expected) {
-      assertThat(expected)
+      Truth.assertThat(expected)
           .hasMessageThat()
           .contains("failed with status = GrpcStatusCode{transportCode=UNAVAILABLE}");
     }
@@ -92,7 +91,7 @@ public class ProtoOperationTransformersTest {
       transformer.apply(operationSnapshot);
       Assert.fail("ResponseTransformer should have thrown an exception");
     } catch (ApiException expected) {
-      assertThat(expected).hasMessageThat().contains("Failed to unpack object");
+      Truth.assertThat(expected).hasMessageThat().contains("Failed to unpack object");
     }
   }
 
@@ -103,7 +102,7 @@ public class ProtoOperationTransformersTest {
     OperationSnapshot operationSnapshot =
         GrpcOperationSnapshot.create(
             Operation.newBuilder().setMetadata(Any.pack(inputMoney)).build());
-    assertThat(transformer.apply(operationSnapshot)).isEqualTo(inputMoney);
+    Truth.assertThat(transformer.apply(operationSnapshot)).isEqualTo(inputMoney);
   }
 
   @Test
@@ -120,7 +119,7 @@ public class ProtoOperationTransformersTest {
       transformer.apply(operationSnapshot);
       Assert.fail("MetadataTransformer should have thrown an exception");
     } catch (ApiException expected) {
-      assertThat(expected).hasMessageThat().contains("Failed to unpack object");
+      Truth.assertThat(expected).hasMessageThat().contains("Failed to unpack object");
     }
   }
 }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/ProtoOperationTransformersTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/ProtoOperationTransformersTest.java
@@ -29,27 +29,26 @@
  */
 package com.google.api.gax.grpc;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.api.gax.grpc.ProtoOperationTransformers.MetadataTransformer;
 import com.google.api.gax.grpc.ProtoOperationTransformers.ResponseTransformer;
 import com.google.api.gax.longrunning.OperationSnapshot;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.UnavailableException;
-import com.google.common.truth.Truth;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.rpc.Status;
 import com.google.type.Color;
 import com.google.type.Money;
 import io.grpc.Status.Code;
-import org.junit.Rule;
+import org.junit.Assert;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class ProtoOperationTransformersTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testResponseTransformer() {
@@ -58,27 +57,30 @@ public class ProtoOperationTransformersTest {
     OperationSnapshot operationSnapshot =
         GrpcOperationSnapshot.create(
             Operation.newBuilder().setResponse(Any.pack(inputMoney)).build());
-    Truth.assertThat(transformer.apply(operationSnapshot)).isEqualTo(inputMoney);
+    assertThat(transformer.apply(operationSnapshot)).isEqualTo(inputMoney);
   }
 
   @Test
   public void testResponseTransformer_exception() {
-    thrown.expect(UnavailableException.class);
     ResponseTransformer<Money> transformer = ResponseTransformer.create(Money.class);
     Money inputMoney = Money.newBuilder().setCurrencyCode("USD").build();
     Status status = Status.newBuilder().setCode(Code.UNAVAILABLE.value()).build();
     OperationSnapshot operationSnapshot =
         GrpcOperationSnapshot.create(
             Operation.newBuilder().setResponse(Any.pack(inputMoney)).setError(status).build());
-    Truth.assertThat(transformer.apply(operationSnapshot)).isEqualTo(inputMoney);
+    try {
+      transformer.apply(operationSnapshot);
+      Assert.fail("ResponseTransformer should have thrown an exception");
+    } catch (UnavailableException expected) {
+      assertThat(expected)
+          .hasMessageThat()
+          .contains("failed with status = GrpcStatusCode{transportCode=UNAVAILABLE}");
+    }
   }
 
   @Test
   public void testResponseTransformer_mismatchedTypes() {
-    thrown.expect(ApiException.class);
-    thrown.expectMessage("Failed to unpack object");
     ResponseTransformer<Money> transformer = ResponseTransformer.create(Money.class);
-    Money inputMoney = Money.newBuilder().setCurrencyCode("USD").build();
     Status status = Status.newBuilder().setCode(Code.OK.value()).build();
     OperationSnapshot operationSnapshot =
         GrpcOperationSnapshot.create(
@@ -86,7 +88,12 @@ public class ProtoOperationTransformersTest {
                 .setResponse(Any.pack(Color.getDefaultInstance()))
                 .setError(status)
                 .build());
-    Truth.assertThat(transformer.apply(operationSnapshot)).isEqualTo(inputMoney);
+    try {
+      transformer.apply(operationSnapshot);
+      Assert.fail("ResponseTransformer should have thrown an exception");
+    } catch (ApiException expected) {
+      assertThat(expected).hasMessageThat().contains("Failed to unpack object");
+    }
   }
 
   @Test
@@ -96,15 +103,12 @@ public class ProtoOperationTransformersTest {
     OperationSnapshot operationSnapshot =
         GrpcOperationSnapshot.create(
             Operation.newBuilder().setMetadata(Any.pack(inputMoney)).build());
-    Truth.assertThat(transformer.apply(operationSnapshot)).isEqualTo(inputMoney);
+    assertThat(transformer.apply(operationSnapshot)).isEqualTo(inputMoney);
   }
 
   @Test
   public void testMetadataTransformer_mismatchedTypes() {
-    thrown.expect(ApiException.class);
-    thrown.expectMessage("Failed to unpack object");
     MetadataTransformer<Money> transformer = MetadataTransformer.create(Money.class);
-    Money inputMoney = Money.newBuilder().setCurrencyCode("USD").build();
     Status status = Status.newBuilder().setCode(Code.OK.value()).build();
     OperationSnapshot operationSnapshot =
         GrpcOperationSnapshot.create(
@@ -112,6 +116,11 @@ public class ProtoOperationTransformersTest {
                 .setMetadata(Any.pack(Color.getDefaultInstance()))
                 .setError(status)
                 .build());
-    Truth.assertThat(transformer.apply(operationSnapshot)).isEqualTo(inputMoney);
+    try {
+      transformer.apply(operationSnapshot);
+      Assert.fail("MetadataTransformer should have thrown an exception");
+    } catch (ApiException expected) {
+      assertThat(expected).hasMessageThat().contains("Failed to unpack object");
+    }
   }
 }

--- a/gax-grpc/src/test/java/com/google/api/gax/grpc/SettingsTest.java
+++ b/gax-grpc/src/test/java/com/google/api/gax/grpc/SettingsTest.java
@@ -57,9 +57,7 @@ import com.google.common.collect.Lists;
 import com.google.common.truth.Truth;
 import java.io.IOException;
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
@@ -67,8 +65,6 @@ import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class SettingsTest {
-
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   interface FakePagedListResponse extends PagedListResponse<Integer> {}
 

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ApiMessageOperationTransformersTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/ApiMessageOperationTransformersTest.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.api.gax.httpjson.ApiMessageOperationTransformers.MetadataTransformer;
 import com.google.api.gax.httpjson.ApiMessageOperationTransformers.ResponseTransformer;
 import com.google.api.gax.httpjson.testing.FakeApiMessage;
@@ -40,6 +38,7 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.api.gax.rpc.StatusCode.Code;
 import com.google.api.gax.rpc.UnavailableException;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.truth.Truth;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
@@ -60,7 +59,7 @@ public class ApiMessageOperationTransformersTest {
         new OperationSnapshotImpl(
             new FakeOperationMessage<>("Pending; no response method", emptyResponse, metadata));
 
-    assertThat(transformer.apply(operationSnapshot)).isEqualTo(emptyResponse);
+    Truth.assertThat(transformer.apply(operationSnapshot)).isEqualTo(emptyResponse);
   }
 
   @Test
@@ -75,7 +74,7 @@ public class ApiMessageOperationTransformersTest {
       transformer.apply(operationSnapshot);
       Assert.fail("ResponseTransformer should have thrown an exception");
     } catch (UnavailableException expected) {
-      assertThat(expected).hasMessageThat().contains("Unavailable; no response method");
+      Truth.assertThat(expected).hasMessageThat().contains("Unavailable; no response method");
     }
   }
 
@@ -92,7 +91,7 @@ public class ApiMessageOperationTransformersTest {
       transformer.apply(operationSnapshot);
       Assert.fail("ResponseTransformer should have thrown an exception");
     } catch (ApiException expected) {
-      assertThat(expected).hasMessageThat().contains("cannot be cast");
+      Truth.assertThat(expected).hasMessageThat().contains("cannot be cast");
     }
   }
 
@@ -104,7 +103,7 @@ public class ApiMessageOperationTransformersTest {
     FakeMetadataMessage metadataMessage = new FakeMetadataMessage(Status.PENDING, Code.OK);
     FakeOperationMessage operation = new FakeOperationMessage<>("foo", returnType, metadataMessage);
     OperationSnapshot operationSnapshot = new OperationSnapshotImpl(operation);
-    assertThat(transformer.apply(operationSnapshot)).isEqualTo(metadataMessage);
+    Truth.assertThat(transformer.apply(operationSnapshot)).isEqualTo(metadataMessage);
   }
 
   @Test
@@ -121,7 +120,7 @@ public class ApiMessageOperationTransformersTest {
       transformer.apply(operationSnapshot);
       Assert.fail("MetadataTransformer should have thrown an exception");
     } catch (ApiException expected) {
-      assertThat(expected).hasMessageThat().contains("cannot be cast");
+      Truth.assertThat(expected).hasMessageThat().contains("cannot be cast");
     }
   }
 

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallContextTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonCallContextTest.java
@@ -35,9 +35,8 @@ import com.google.api.gax.rpc.testing.FakeTransportChannel;
 import com.google.api.gax.tracing.ApiTracer;
 import com.google.auth.Credentials;
 import com.google.common.truth.Truth;
-import org.junit.Rule;
+import org.junit.Assert;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
@@ -45,12 +44,17 @@ import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class HttpJsonCallContextTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testNullToSelfWrongType() {
-    thrown.expect(IllegalArgumentException.class);
-    HttpJsonCallContext.createDefault().nullToSelf(FakeCallContext.createDefault());
+    try {
+      HttpJsonCallContext.createDefault().nullToSelf(FakeCallContext.createDefault());
+      Assert.fail("HttpJsonCallContext should have thrown an exception");
+    } catch (IllegalArgumentException expected) {
+      Truth.assertThat(expected)
+          .hasMessageThat()
+          .contains("context must be an instance of HttpJsonCallContext");
+    }
   }
 
   @Test
@@ -75,15 +79,26 @@ public class HttpJsonCallContextTest {
 
   @Test
   public void testWithTransportChannelWrongType() {
-    thrown.expect(IllegalArgumentException.class);
-    FakeChannel channel = new FakeChannel();
-    HttpJsonCallContext.createDefault().withTransportChannel(FakeTransportChannel.create(channel));
+    try {
+      FakeChannel channel = new FakeChannel();
+      HttpJsonCallContext.createDefault()
+          .withTransportChannel(FakeTransportChannel.create(channel));
+      Assert.fail("HttpJsonCallContext should have thrown an exception");
+    } catch (IllegalArgumentException expected) {
+      Truth.assertThat(expected).hasMessageThat().contains("Expected HttpJsonTransportChannel");
+    }
   }
 
   @Test
   public void testMergeWrongType() {
-    thrown.expect(IllegalArgumentException.class);
-    HttpJsonCallContext.createDefault().merge(FakeCallContext.createDefault());
+    try {
+      HttpJsonCallContext.createDefault().merge(FakeCallContext.createDefault());
+      Assert.fail("HttpJsonCallContext should have thrown an exception");
+    } catch (IllegalArgumentException expected) {
+      Truth.assertThat(expected)
+          .hasMessageThat()
+          .contains("context must be an instance of HttpJsonCallContext");
+    }
   }
 
   @Test

--- a/gax-httpjson/src/test/java/com/google/api/gax/httpjson/RetryingTest.java
+++ b/gax-httpjson/src/test/java/com/google/api/gax/httpjson/RetryingTest.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.httpjson;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.HttpStatusCodes;
@@ -50,6 +48,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.gax.rpc.UnknownException;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.truth.Truth;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.util.Set;
@@ -130,7 +129,7 @@ public class RetryingTest {
         createSettings(retryable, FAST_RETRY_SETTINGS);
     UnaryCallable<Integer, Integer> callable =
         HttpJsonCallableFactory.createUnaryCallable(callInt, callSettings, clientContext);
-    assertThat(callable.call(1)).isEqualTo(2);
+    Truth.assertThat(callable.call(1)).isEqualTo(2);
   }
 
   @Test(expected = ApiException.class)
@@ -192,7 +191,7 @@ public class RetryingTest {
     UnaryCallable<Integer, Integer> callable =
         HttpJsonCallableFactory.createUnaryCallable(callInt, callSettings, clientContext);
     callable.call(1);
-    assertThat(callable.call(1)).isEqualTo(2);
+    Truth.assertThat(callable.call(1)).isEqualTo(2);
   }
 
   @Test
@@ -212,7 +211,7 @@ public class RetryingTest {
         createSettings(retryable, FAST_RETRY_SETTINGS);
     UnaryCallable<Integer, Integer> callable =
         HttpJsonCallableFactory.createUnaryCallable(callInt, callSettings, clientContext);
-    assertThat(callable.call(1)).isEqualTo(2);
+    Truth.assertThat(callable.call(1)).isEqualTo(2);
   }
 
   @Test
@@ -229,7 +228,7 @@ public class RetryingTest {
       callable.call(1);
       Assert.fail("Callable should have thrown an exception");
     } catch (ApiException expected) {
-      assertThat(expected).hasCauseThat().isSameInstanceAs(throwable);
+      Truth.assertThat(expected).hasCauseThat().isSameInstanceAs(throwable);
     }
   }
 
@@ -256,7 +255,7 @@ public class RetryingTest {
       callable.call(1);
       Assert.fail("Callable should have thrown an exception");
     } catch (ApiException expected) {
-      assertThat(expected).isSameInstanceAs(apiException);
+      Truth.assertThat(expected).isSameInstanceAs(apiException);
     }
   }
 
@@ -280,8 +279,8 @@ public class RetryingTest {
       Futures.getUnchecked(future);
       Assert.fail("Callable should have thrown an exception");
     } catch (UncheckedExecutionException expected) {
-      assertThat(expected).hasCauseThat().isInstanceOf(ApiException.class);
-      assertThat(expected).hasCauseThat().hasMessageThat().contains("Unavailable");
+      Truth.assertThat(expected).hasCauseThat().isInstanceOf(ApiException.class);
+      Truth.assertThat(expected).hasCauseThat().hasMessageThat().contains("Unavailable");
     }
   }
 
@@ -320,9 +319,9 @@ public class RetryingTest {
       callable.call(1);
       Assert.fail("Callable should have thrown an exception");
     } catch (FailedPreconditionException expected) {
-      assertThat(((HttpJsonStatusCode) expected.getStatusCode()).getTransportCode())
+      Truth.assertThat(((HttpJsonStatusCode) expected.getStatusCode()).getTransportCode())
           .isEqualTo(STATUS_FAILED_PRECONDITION);
-      assertThat(expected.getMessage()).contains(HttpJsonStatusCode.FAILED_PRECONDITION);
+      Truth.assertThat(expected.getMessage()).contains(HttpJsonStatusCode.FAILED_PRECONDITION);
     }
   }
 
@@ -341,7 +340,7 @@ public class RetryingTest {
       callable.call(1);
       Assert.fail("Callable should have thrown an exception");
     } catch (UnknownException expected) {
-      assertThat(expected.getMessage()).isEqualTo("java.lang.RuntimeException: unknown");
+      Truth.assertThat(expected.getMessage()).isEqualTo("java.lang.RuntimeException: unknown");
     }
   }
 

--- a/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
+++ b/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
@@ -41,9 +41,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.threeten.bp.Duration;
 
 public class ThresholdBatcherTest {
@@ -104,8 +102,6 @@ public class ThresholdBatcherTest {
           }
         });
   }
-
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   private static class SimpleBatch {
 
@@ -220,15 +216,19 @@ public class ThresholdBatcherTest {
 
   @Test
   public void testExceptionWithNullFlowController() {
-    thrown.expect(NullPointerException.class);
-    ThresholdBatcher.<SimpleBatch>newBuilder()
-        .setThresholds(BatchingThresholds.<SimpleBatch>create(100))
-        .setExecutor(EXECUTOR)
-        .setMaxDelay(Duration.ofMillis(10000))
-        .setReceiver(
-            new AccumulatingBatchReceiver<SimpleBatch>(ApiFutures.<Void>immediateFuture(null)))
-        .setBatchMerger(new SimpleBatchMerger())
-        .build();
+    try {
+      ThresholdBatcher.<SimpleBatch>newBuilder()
+          .setThresholds(BatchingThresholds.<SimpleBatch>create(100))
+          .setExecutor(EXECUTOR)
+          .setMaxDelay(Duration.ofMillis(10000))
+          .setReceiver(
+              new AccumulatingBatchReceiver<SimpleBatch>(ApiFutures.<Void>immediateFuture(null)))
+          .setBatchMerger(new SimpleBatchMerger())
+          .build();
+      Assert.fail("ThresholdBatcher should have thrown an exception");
+    } catch (NullPointerException expected) {
+      assertThat(expected).isInstanceOf(NullPointerException.class);
+    }
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/rpc/ApiExceptionsTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/ApiExceptionsTest.java
@@ -40,15 +40,13 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.io.IOException;
 import java.util.concurrent.Executors;
-import org.junit.Rule;
+import org.junit.Assert;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class ApiExceptionsTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void noException() {
@@ -58,23 +56,36 @@ public class ApiExceptionsTest {
 
   @Test
   public void throwsApiException() {
-    thrown.expect(ApiException.class);
-    ApiExceptions.callAndTranslateApiException(
-        ApiFutures.immediateFailedFuture(
-            new UnavailableException(null, FakeStatusCode.of(StatusCode.Code.UNAVAILABLE), false)));
+    Exception throwable =
+        new UnavailableException(null, FakeStatusCode.of(StatusCode.Code.UNAVAILABLE), false);
+    try {
+      ApiExceptions.callAndTranslateApiException(ApiFutures.immediateFailedFuture(throwable));
+      Assert.fail("ApiExceptions should have thrown an exception");
+    } catch (ApiException expected) {
+      assertThat(expected).isSameInstanceAs(throwable);
+    }
   }
 
   @Test
   public void throwsIOException() {
-    thrown.expect(UncheckedExecutionException.class);
-    ApiExceptions.callAndTranslateApiException(ApiFutures.immediateFailedFuture(new IOException()));
+    try {
+      ApiExceptions.callAndTranslateApiException(
+          ApiFutures.immediateFailedFuture(new IOException()));
+      Assert.fail("ApiExceptions should have thrown an exception");
+    } catch (UncheckedExecutionException expected) {
+      assertThat(expected).hasCauseThat().isInstanceOf(IOException.class);
+    }
   }
 
   @Test
   public void throwsRuntimeException() {
-    thrown.expect(IllegalArgumentException.class);
-    ApiExceptions.callAndTranslateApiException(
-        ApiFutures.immediateFailedFuture(new IllegalArgumentException()));
+    try {
+      ApiExceptions.callAndTranslateApiException(
+          ApiFutures.immediateFailedFuture(new IllegalArgumentException()));
+      Assert.fail("ApiExceptions should have thrown an exception");
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).isInstanceOf(IllegalArgumentException.class);
+    }
   }
 
   /**

--- a/gax/src/test/java/com/google/api/gax/rpc/BatchedRequestIssuerTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/BatchedRequestIssuerTest.java
@@ -29,8 +29,7 @@
  */
 package com.google.api.gax.rpc;
 
-import static com.google.common.truth.Truth.assertThat;
-
+import com.google.common.truth.Truth;
 import java.util.concurrent.ExecutionException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -43,11 +42,11 @@ public class BatchedRequestIssuerTest {
     BatchedRequestIssuer<Integer> issuer = new BatchedRequestIssuer<>(batchedFuture, 2);
     issuer.setResponse(1);
 
-    assertThat(batchedFuture.isDone()).isFalse();
+    Truth.assertThat(batchedFuture.isDone()).isFalse();
     issuer.sendResult();
 
-    assertThat(batchedFuture.isDone()).isTrue();
-    assertThat(batchedFuture.get()).isEqualTo(1);
+    Truth.assertThat(batchedFuture.isDone()).isTrue();
+    Truth.assertThat(batchedFuture.get()).isEqualTo(1);
   }
 
   @Test
@@ -56,11 +55,11 @@ public class BatchedRequestIssuerTest {
     BatchedRequestIssuer<Integer> issuer = new BatchedRequestIssuer<>(batchedFuture, 2);
     issuer.setResponse(null);
 
-    assertThat(batchedFuture.isDone()).isFalse();
+    Truth.assertThat(batchedFuture.isDone()).isFalse();
     issuer.sendResult();
 
-    assertThat(batchedFuture.isDone()).isTrue();
-    assertThat(batchedFuture.get()).isNull();
+    Truth.assertThat(batchedFuture.isDone()).isTrue();
+    Truth.assertThat(batchedFuture.get()).isNull();
   }
 
   @Test
@@ -71,15 +70,15 @@ public class BatchedRequestIssuerTest {
     BatchedRequestIssuer<Integer> issuer = new BatchedRequestIssuer<>(batchedFuture, 2);
     issuer.setException(thrownException);
 
-    assertThat(batchedFuture.isDone()).isFalse();
+    Truth.assertThat(batchedFuture.isDone()).isFalse();
     issuer.sendResult();
 
-    assertThat(batchedFuture.isDone()).isTrue();
+    Truth.assertThat(batchedFuture.isDone()).isTrue();
     try {
       batchedFuture.get();
       Assert.fail("BatchedFuture should have thrown an exception");
     } catch (ExecutionException e) {
-      assertThat(e.getCause()).isInstanceOf(IllegalArgumentException.class);
+      Truth.assertThat(e.getCause()).isInstanceOf(IllegalArgumentException.class);
     }
   }
 
@@ -91,7 +90,7 @@ public class BatchedRequestIssuerTest {
       issuer.sendResult();
       Assert.fail("BatchedFuture should have thrown an exception");
     } catch (IllegalStateException expected) {
-      assertThat(expected)
+      Truth.assertThat(expected)
           .hasMessageThat()
           .contains("Neither response nor exception were set in BatchedRequestIssuer");
     }
@@ -107,7 +106,9 @@ public class BatchedRequestIssuerTest {
       issuer.setException(thrownException);
       Assert.fail("BatchedFuture should have thrown an exception");
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().contains("Cannot set both exception and response");
+      Truth.assertThat(expected)
+          .hasMessageThat()
+          .contains("Cannot set both exception and response");
     }
   }
 
@@ -121,7 +122,9 @@ public class BatchedRequestIssuerTest {
       issuer.setResponse(1);
       Assert.fail("BatchedFuture should have thrown an exception");
     } catch (IllegalStateException expected) {
-      assertThat(expected).hasMessageThat().contains("Cannot set both exception and response");
+      Truth.assertThat(expected)
+          .hasMessageThat()
+          .contains("Cannot set both exception and response");
     }
   }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/BatchedRequestIssuerTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/BatchedRequestIssuerTest.java
@@ -29,16 +29,13 @@
  */
 package com.google.api.gax.rpc;
 
-import com.google.common.truth.Truth;
+import static com.google.common.truth.Truth.assertThat;
+
 import java.util.concurrent.ExecutionException;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class BatchedRequestIssuerTest {
-
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void test() throws Exception {
@@ -46,11 +43,11 @@ public class BatchedRequestIssuerTest {
     BatchedRequestIssuer<Integer> issuer = new BatchedRequestIssuer<>(batchedFuture, 2);
     issuer.setResponse(1);
 
-    Truth.assertThat(batchedFuture.isDone()).isFalse();
+    assertThat(batchedFuture.isDone()).isFalse();
     issuer.sendResult();
 
-    Truth.assertThat(batchedFuture.isDone()).isTrue();
-    Truth.assertThat(batchedFuture.get()).isEqualTo(1);
+    assertThat(batchedFuture.isDone()).isTrue();
+    assertThat(batchedFuture.get()).isEqualTo(1);
   }
 
   @Test
@@ -59,11 +56,11 @@ public class BatchedRequestIssuerTest {
     BatchedRequestIssuer<Integer> issuer = new BatchedRequestIssuer<>(batchedFuture, 2);
     issuer.setResponse(null);
 
-    Truth.assertThat(batchedFuture.isDone()).isFalse();
+    assertThat(batchedFuture.isDone()).isFalse();
     issuer.sendResult();
 
-    Truth.assertThat(batchedFuture.isDone()).isTrue();
-    Truth.assertThat(batchedFuture.get()).isNull();
+    assertThat(batchedFuture.isDone()).isTrue();
+    assertThat(batchedFuture.get()).isNull();
   }
 
   @Test
@@ -74,46 +71,57 @@ public class BatchedRequestIssuerTest {
     BatchedRequestIssuer<Integer> issuer = new BatchedRequestIssuer<>(batchedFuture, 2);
     issuer.setException(thrownException);
 
-    Truth.assertThat(batchedFuture.isDone()).isFalse();
+    assertThat(batchedFuture.isDone()).isFalse();
     issuer.sendResult();
 
-    Truth.assertThat(batchedFuture.isDone()).isTrue();
+    assertThat(batchedFuture.isDone()).isTrue();
     try {
       batchedFuture.get();
       Assert.fail("BatchedFuture should have thrown an exception");
     } catch (ExecutionException e) {
-      Truth.assertThat(e.getCause()).isInstanceOf(IllegalArgumentException.class);
+      assertThat(e.getCause()).isInstanceOf(IllegalArgumentException.class);
     }
   }
 
   @Test
   public void testNoResult() {
-    thrown.expect(IllegalStateException.class);
-
-    BatchedFuture<Integer> batchedFuture = BatchedFuture.<Integer>create();
-    BatchedRequestIssuer<Integer> issuer = new BatchedRequestIssuer<>(batchedFuture, 2);
-    issuer.sendResult();
+    try {
+      BatchedFuture<Integer> batchedFuture = BatchedFuture.<Integer>create();
+      BatchedRequestIssuer<Integer> issuer = new BatchedRequestIssuer<>(batchedFuture, 2);
+      issuer.sendResult();
+      Assert.fail("BatchedFuture should have thrown an exception");
+    } catch (IllegalStateException expected) {
+      assertThat(expected)
+          .hasMessageThat()
+          .contains("Neither response nor exception were set in BatchedRequestIssuer");
+    }
   }
 
   @Test
   public void testResponseAndException() {
-    thrown.expect(IllegalStateException.class);
-
-    Exception thrownException = new IllegalArgumentException("bad!");
-    BatchedFuture<Integer> batchedFuture = BatchedFuture.<Integer>create();
-    BatchedRequestIssuer<Integer> issuer = new BatchedRequestIssuer<>(batchedFuture, 2);
-    issuer.setResponse(1);
-    issuer.setException(thrownException);
+    try {
+      Exception thrownException = new IllegalArgumentException("bad!");
+      BatchedFuture<Integer> batchedFuture = BatchedFuture.<Integer>create();
+      BatchedRequestIssuer<Integer> issuer = new BatchedRequestIssuer<>(batchedFuture, 2);
+      issuer.setResponse(1);
+      issuer.setException(thrownException);
+      Assert.fail("BatchedFuture should have thrown an exception");
+    } catch (IllegalStateException expected) {
+      assertThat(expected).hasMessageThat().contains("Cannot set both exception and response");
+    }
   }
 
   @Test
   public void testExceptionAndResponse() {
-    thrown.expect(IllegalStateException.class);
-
-    Exception thrownException = new IllegalArgumentException("bad!");
-    BatchedFuture<Integer> batchedFuture = BatchedFuture.<Integer>create();
-    BatchedRequestIssuer<Integer> issuer = new BatchedRequestIssuer<>(batchedFuture, 2);
-    issuer.setException(thrownException);
-    issuer.setResponse(1);
+    try {
+      Exception thrownException = new IllegalArgumentException("bad!");
+      BatchedFuture<Integer> batchedFuture = BatchedFuture.<Integer>create();
+      BatchedRequestIssuer<Integer> issuer = new BatchedRequestIssuer<>(batchedFuture, 2);
+      issuer.setException(thrownException);
+      issuer.setResponse(1);
+      Assert.fail("BatchedFuture should have thrown an exception");
+    } catch (IllegalStateException expected) {
+      assertThat(expected).hasMessageThat().contains("Cannot set both exception and response");
+    }
   }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/CancellationTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/CancellationTest.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.api.core.AbstractApiFuture;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.SettableApiFuture;
@@ -123,7 +121,7 @@ public class CancellationTest {
       resultFuture.get();
       Assert.fail("Callable should have thrown an exception");
     } catch (CancellationException expected) {
-      assertThat(expected).hasMessageThat().contains("Task was cancelled");
+      Truth.assertThat(expected).hasMessageThat().contains("Task was cancelled");
     }
   }
 

--- a/gax/src/test/java/com/google/api/gax/rpc/CancellationTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/CancellationTest.java
@@ -29,6 +29,8 @@
  */
 package com.google.api.gax.rpc;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.api.core.AbstractApiFuture;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.SettableApiFuture;
@@ -47,10 +49,9 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
@@ -88,8 +89,6 @@ public class CancellationTest {
   private RecordingScheduler executor;
   private ClientContext clientContext;
 
-  @Rule public ExpectedException thrown = ExpectedException.none();
-
   @Before
   public void resetClock() {
     fakeClock = new FakeApiClock(System.nanoTime());
@@ -110,18 +109,22 @@ public class CancellationTest {
 
   @Test
   public void cancellationBeforeGetOnRetryingCallable() throws Exception {
-    thrown.expect(CancellationException.class);
-    Mockito.when(callInt.futureCall((Integer) Mockito.any(), (ApiCallContext) Mockito.any()))
-        .thenReturn(SettableApiFuture.<Integer>create());
+    try {
+      Mockito.when(callInt.futureCall((Integer) Mockito.any(), (ApiCallContext) Mockito.any()))
+          .thenReturn(SettableApiFuture.<Integer>create());
 
-    UnaryCallSettings<Integer, Integer> callSettings =
-        RetryingTest.createSettings(FAST_RETRY_SETTINGS);
-    UnaryCallable<Integer, Integer> callable =
-        FakeCallableFactory.createUnaryCallable(callInt, callSettings, clientContext);
+      UnaryCallSettings<Integer, Integer> callSettings =
+          RetryingTest.createSettings(FAST_RETRY_SETTINGS);
+      UnaryCallable<Integer, Integer> callable =
+          FakeCallableFactory.createUnaryCallable(callInt, callSettings, clientContext);
 
-    ApiFuture<Integer> resultFuture = callable.futureCall(0);
-    resultFuture.cancel(true);
-    resultFuture.get();
+      ApiFuture<Integer> resultFuture = callable.futureCall(0);
+      resultFuture.cancel(true);
+      resultFuture.get();
+      Assert.fail("Callable should have thrown an exception");
+    } catch (CancellationException expected) {
+      assertThat(expected).hasMessageThat().contains("Task was cancelled");
+    }
   }
 
   private static class CancellationTrackingFuture<RespT> extends AbstractApiFuture<RespT> {

--- a/gax/src/test/java/com/google/api/gax/rpc/FirstElementCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/FirstElementCallableTest.java
@@ -37,9 +37,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -47,8 +45,6 @@ import org.junit.runners.JUnit4;
 public class FirstElementCallableTest {
   private MockServerStreamingCallable<String, String> upstream;
   private FirstElementCallable<String, String> callable;
-
-  @Rule public ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setup() {

--- a/gax/src/test/java/com/google/api/gax/rpc/RetryingTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/RetryingTest.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.core.FakeApiClock;
@@ -43,6 +41,7 @@ import com.google.api.gax.rpc.testing.FakeChannel;
 import com.google.api.gax.rpc.testing.FakeStatusCode;
 import com.google.api.gax.rpc.testing.FakeTransportChannel;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.truth.Truth;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.junit.After;
@@ -202,7 +201,7 @@ public class RetryingTest {
       assertRetrying(FAST_RETRY_SETTINGS);
       Assert.fail("Callable should have thrown an exception");
     } catch (ApiException expected) {
-      assertThat(expected).isSameInstanceAs(throwable);
+      Truth.assertThat(expected).isSameInstanceAs(throwable);
     }
   }
 
@@ -218,7 +217,7 @@ public class RetryingTest {
       assertRetrying(FAST_RETRY_SETTINGS);
       Assert.fail("Callable should have thrown an exception");
     } catch (ApiException expected) {
-      assertThat(expected).isSameInstanceAs(throwable);
+      Truth.assertThat(expected).isSameInstanceAs(throwable);
     }
   }
 
@@ -238,7 +237,7 @@ public class RetryingTest {
       Futures.getUnchecked(future);
       Assert.fail("Callable should have thrown an exception");
     } catch (UncheckedExecutionException expected) {
-      assertThat(expected).hasCauseThat().isSameInstanceAs(throwable);
+      Truth.assertThat(expected).hasCauseThat().isSameInstanceAs(throwable);
     }
   }
 
@@ -260,7 +259,7 @@ public class RetryingTest {
       callable.call(1);
       Assert.fail("Callable should have thrown an exception");
     } catch (FailedPreconditionException expected) {
-      assertThat(expected.getMessage()).isEqualTo("known");
+      Truth.assertThat(expected.getMessage()).isEqualTo("known");
     }
   }
 
@@ -279,7 +278,7 @@ public class RetryingTest {
       callable.call(1);
       Assert.fail("Callable should have thrown an exception");
     } catch (RuntimeException expected) {
-      assertThat(expected).isInstanceOf(RuntimeException.class);
+      Truth.assertThat(expected).isInstanceOf(RuntimeException.class);
     }
   }
 
@@ -294,6 +293,6 @@ public class RetryingTest {
     UnaryCallSettings<Integer, Integer> callSettings = createSettings(retrySettings);
     UnaryCallable<Integer, Integer> callable =
         FakeCallableFactory.createUnaryCallable(callInt, callSettings, clientContext);
-    assertThat(callable.call(1)).isEqualTo(2);
+    Truth.assertThat(callable.call(1)).isEqualTo(2);
   }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/RetryingTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/RetryingTest.java
@@ -29,6 +29,8 @@
  */
 package com.google.api.gax.rpc;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.gax.core.FakeApiClock;
@@ -41,14 +43,12 @@ import com.google.api.gax.rpc.testing.FakeChannel;
 import com.google.api.gax.rpc.testing.FakeStatusCode;
 import com.google.api.gax.rpc.testing.FakeTransportChannel;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.truth.Truth;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
@@ -92,8 +92,6 @@ public class RetryingTest {
   public void teardown() {
     executor.shutdownNow();
   }
-
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   static <V> ApiFuture<V> immediateFailedFuture(Throwable t) {
     return ApiFutures.<V>immediateFailedFuture(t);
@@ -196,43 +194,52 @@ public class RetryingTest {
 
   @Test
   public void retryOnUnexpectedException() {
-    thrown.expect(ApiException.class);
-    thrown.expectMessage("foobar");
     Throwable throwable =
         new UnknownException("foobar", null, FakeStatusCode.of(StatusCode.Code.UNKNOWN), false);
     Mockito.when(callInt.futureCall((Integer) Mockito.any(), (ApiCallContext) Mockito.any()))
         .thenReturn(RetryingTest.<Integer>immediateFailedFuture(throwable));
-    assertRetrying(FAST_RETRY_SETTINGS);
+    try {
+      assertRetrying(FAST_RETRY_SETTINGS);
+      Assert.fail("Callable should have thrown an exception");
+    } catch (ApiException expected) {
+      assertThat(expected).isSameInstanceAs(throwable);
+    }
   }
 
   @Test
   public void retryNoRecover() {
-    thrown.expect(ApiException.class);
-    thrown.expectMessage("foobar");
+    Throwable throwable =
+        new FailedPreconditionException(
+            "foobar", null, FakeStatusCode.of(StatusCode.Code.FAILED_PRECONDITION), false);
     Mockito.when(callInt.futureCall((Integer) Mockito.any(), (ApiCallContext) Mockito.any()))
-        .thenReturn(
-            RetryingTest.<Integer>immediateFailedFuture(
-                new FailedPreconditionException(
-                    "foobar", null, FakeStatusCode.of(StatusCode.Code.FAILED_PRECONDITION), false)))
+        .thenReturn(RetryingTest.<Integer>immediateFailedFuture(throwable))
         .thenReturn(ApiFutures.<Integer>immediateFuture(2));
-    assertRetrying(FAST_RETRY_SETTINGS);
+    try {
+      assertRetrying(FAST_RETRY_SETTINGS);
+      Assert.fail("Callable should have thrown an exception");
+    } catch (ApiException expected) {
+      assertThat(expected).isSameInstanceAs(throwable);
+    }
   }
 
   @Test
   public void retryKeepFailing() {
-    thrown.expect(UncheckedExecutionException.class);
-    thrown.expectMessage("foobar");
+    Throwable throwable =
+        new UnavailableException(
+            "foobar", null, FakeStatusCode.of(StatusCode.Code.UNAVAILABLE), true);
     Mockito.when(callInt.futureCall((Integer) Mockito.any(), (ApiCallContext) Mockito.any()))
-        .thenReturn(
-            RetryingTest.<Integer>immediateFailedFuture(
-                new UnavailableException(
-                    "foobar", null, FakeStatusCode.of(StatusCode.Code.UNAVAILABLE), true)));
+        .thenReturn(RetryingTest.<Integer>immediateFailedFuture(throwable));
     UnaryCallSettings<Integer, Integer> callSettings = createSettings(FAST_RETRY_SETTINGS);
     UnaryCallable<Integer, Integer> callable =
         FakeCallableFactory.createUnaryCallable(callInt, callSettings, clientContext);
     // Need to advance time inside the call.
     ApiFuture<Integer> future = callable.futureCall(1);
-    Futures.getUnchecked(future);
+    try {
+      Futures.getUnchecked(future);
+      Assert.fail("Callable should have thrown an exception");
+    } catch (UncheckedExecutionException expected) {
+      assertThat(expected).hasCauseThat().isSameInstanceAs(throwable);
+    }
   }
 
   @Test
@@ -251,14 +258,14 @@ public class RetryingTest {
         FakeCallableFactory.createUnaryCallable(callInt, callSettings, clientContext);
     try {
       callable.call(1);
-    } catch (FailedPreconditionException exception) {
-      Truth.assertThat(exception.getMessage()).isEqualTo("known");
+      Assert.fail("Callable should have thrown an exception");
+    } catch (FailedPreconditionException expected) {
+      assertThat(expected.getMessage()).isEqualTo("known");
     }
   }
 
   @Test
   public void testUnknownStatusCode() {
-    thrown.expect(RuntimeException.class);
     ImmutableSet<StatusCode.Code> retryable = ImmutableSet.of();
     Mockito.when(callInt.futureCall((Integer) Mockito.any(), (ApiCallContext) Mockito.any()))
         .thenReturn(RetryingTest.<Integer>immediateFailedFuture(new RuntimeException("unknown")));
@@ -268,7 +275,12 @@ public class RetryingTest {
             .build();
     UnaryCallable<Integer, Integer> callable =
         FakeCallableFactory.createUnaryCallable(callInt, callSettings, clientContext);
-    callable.call(1);
+    try {
+      callable.call(1);
+      Assert.fail("Callable should have thrown an exception");
+    } catch (RuntimeException expected) {
+      assertThat(expected).isInstanceOf(RuntimeException.class);
+    }
   }
 
   public static UnaryCallSettings<Integer, Integer> createSettings(RetrySettings retrySettings) {
@@ -282,6 +294,6 @@ public class RetryingTest {
     UnaryCallSettings<Integer, Integer> callSettings = createSettings(retrySettings);
     UnaryCallable<Integer, Integer> callable =
         FakeCallableFactory.createUnaryCallable(callInt, callSettings, clientContext);
-    Truth.assertThat(callable.call(1)).isEqualTo(2);
+    assertThat(callable.call(1)).isEqualTo(2);
   }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/SpoolingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/SpoolingCallableTest.java
@@ -38,10 +38,9 @@ import com.google.common.truth.Truth;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -49,8 +48,6 @@ import org.junit.runners.JUnit4;
 public class SpoolingCallableTest {
   private MockServerStreamingCallable<String, String> upstream;
   private SpoolingCallable<String, String> callable;
-
-  @Rule public ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setup() {
@@ -91,8 +88,12 @@ public class SpoolingCallableTest {
         .onError(new RuntimeException("Some other upstream cancellation indicator"));
 
     // However the inner cancellation exception will be masked by an outer CancellationException
-    expectedException.expect(CancellationException.class);
-    result.get();
+    try {
+      result.get();
+      Assert.fail("Callable should have thrown an exception");
+    } catch (CancellationException expected) {
+      Truth.assertThat(expected).hasMessageThat().contains("Task was cancelled.");
+    }
   }
 
   @Test

--- a/gax/src/test/java/com/google/api/gax/rpc/SpoolingCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/SpoolingCallableTest.java
@@ -29,8 +29,6 @@
  */
 package com.google.api.gax.rpc;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.rpc.testing.MockStreamingApi.MockServerStreamingCall;
 import com.google.api.gax.rpc.testing.MockStreamingApi.MockServerStreamingCallable;
@@ -60,13 +58,13 @@ public class SpoolingCallableTest {
     ApiFuture<List<String>> result = callable.futureCall("request");
     MockServerStreamingCall<String, String> call = upstream.popLastCall();
 
-    assertThat(call.getController().isAutoFlowControlEnabled()).isTrue();
+    Truth.assertThat(call.getController().isAutoFlowControlEnabled()).isTrue();
 
     call.getController().getObserver().onResponse("response1");
     call.getController().getObserver().onResponse("response2");
     call.getController().getObserver().onComplete();
 
-    assertThat(result.get()).containsExactly("response1", "response2").inOrder();
+    Truth.assertThat(result.get()).containsExactly("response1", "response2").inOrder();
   }
 
   @Test
@@ -103,6 +101,6 @@ public class SpoolingCallableTest {
 
     call.getController().getObserver().onComplete();
 
-    assertThat(result.get()).isEmpty();
+    Truth.assertThat(result.get()).isEmpty();
   }
 }

--- a/gax/src/test/java/com/google/api/gax/rpc/UnaryCallableTest.java
+++ b/gax/src/test/java/com/google/api/gax/rpc/UnaryCallableTest.java
@@ -34,9 +34,7 @@ import com.google.api.gax.rpc.testing.FakeChannel;
 import com.google.api.gax.rpc.testing.FakeSimpleApi.StashCallable;
 import com.google.auth.Credentials;
 import com.google.common.truth.Truth;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
@@ -44,7 +42,6 @@ import org.mockito.Mockito;
 /** Tests for {@link UnaryCallable}. */
 @RunWith(JUnit4.class)
 public class UnaryCallableTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void simpleCall() throws Exception {


### PR DESCRIPTION
removed deprecated `ExpectedException.none()` usage across unit test cases.